### PR TITLE
Support delegated auth cookies with : characters

### DIFF
--- a/src/delegated_auth.erl
+++ b/src/delegated_auth.erl
@@ -39,7 +39,7 @@ delegated_authentication_handler(#httpd{mochi_req=MochiReq}=Req) ->
     Cookie ->
         [User, Roles, TimeStr | MacParts] = try
             DelegatedAuth = couch_util:decodeBase64Url(Cookie),
-            string:tokens(?b2l(DelegatedAuth), ":")
+            re:split(?b2l(DelegatedAuth), ":", [{return, list}])
         catch
             _:_Error ->
                 throw({bad_request, <<"Malformed DelegatedAuth cookie.">>})


### PR DESCRIPTION
The string:tokens function silently drops any empty token,
thus giving a spurious failure for valid input. The fix changes this
mechanism to one that losslessly decodes this part.

c.f COUCHDB-1607

BugzID: 25223
