### PR TITLE
Extend gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-ebin
+.project
+ebin/*.beam
+ebin/*.app
+TEST-*
+.eunit


### PR DESCRIPTION
I used the small .gitignore from mem3 as template.

I don't know if ebin is better than ebin/_.beam ebin/_.app here.

The .project comes from showroom in an attempt towards a consistent minimal .gitignore across projects.
